### PR TITLE
Updates to make web version run without problems

### DIFF
--- a/configs/theme.js
+++ b/configs/theme.js
@@ -1,0 +1,17 @@
+// additional theming extending the default react-native-elements theme
+export default {
+  colors: {
+    platform: {
+      // setting a default for `web` platform for example, which is not defined by default
+      default: {
+        primary: '#2196f3',
+        secondary: '#9C27B0',
+        grey: 'rgba(0, 0, 0, 0.54)',
+        searchBg: '#dcdce1',
+        success: '#4caf50',
+        error: '#f44336',
+        warning: '#ffeb3b'
+      }
+    }
+  }
+};

--- a/navigation/useLinking.js
+++ b/navigation/useLinking.js
@@ -1,5 +1,5 @@
 import { useLinking } from '@react-navigation/native';
-import { Linking } from 'expo';
+import * as Linking from 'expo-linking'
 
 export default function (containerRef) {
   return useLinking(containerRef, {

--- a/navigation/useLinking.js
+++ b/navigation/useLinking.js
@@ -6,11 +6,12 @@ export default function (containerRef) {
     prefixes: [Linking.makeUrl('/')],
     config: {
       Root: {
-        path: 'root',
+        path: '',
         screens: {
           Home: 'home',
           Links: 'links',
-          Settings: 'settings'
+          Settings: 'settings',
+          ExpenseTracker: 'expense-tracker'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-asset": "~8.1.7",
     "expo-constants": "~9.1.1",
     "expo-font": "~8.2.1",
+    "expo-linking": "^1.0.3",
     "expo-web-browser": "~8.3.1",
     "react": "16.11.0",
     "react-dom": "16.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3509,7 +3509,7 @@ expo-linear-gradient@~8.2.1:
   dependencies:
     prop-types "15.7.2"
 
-expo-linking@~1.0.3:
+expo-linking@^1.0.3, expo-linking@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-1.0.3.tgz#8c0f68e89262d09d4b280479010ac21ccfa1e971"
   integrity sha512-Bzm8qVlSRBmoQcnveBBLO4ea/AEW4t10WFiJ18m/w8OnEXbsP7WT39UyhTuFsrnjYSLMjW4/JXkfmswBOhISuA==


### PR DESCRIPTION
- updated `ExpenseTrackerScreen` component to avoid conflicts with web platform
  - added `ThemeProvider` with an extended theme for `ListItems` to work
    - set the `default` with copied values of the `platform` part for ios/android of react-native-elements
    - otherwise the `ListItem` errors with not finding a value for `grey`
- removed `root` from web urls
- added web url for `ExpenseTrackerScreen` component

![Bildschirmfoto am 2020-09-10 um 15 23 07-down](https://user-images.githubusercontent.com/1942953/92738884-a2243e80-f37c-11ea-92cb-ec16618b0b15.png)
